### PR TITLE
Add quotes around keys in credentials.ini example

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -16,10 +16,10 @@ The requirements are in *composer.json*. Install them using composer:
 If you already have a consumer key/secret pair and access token/secret pair, you can create *credentials.ini* in
 this directory:
 
-    consumerKey = ****
-    consumerSecret = ****
-    accessKey = ****
-    accessSecret = ****
+    consumerKey = '****'
+    consumerSecret = '****'
+    accessKey = '****'
+    accessSecret = '****'
 
 You can also create the *credentials.ini* file using your existing consumer key and secret from the
 [My Apps page](https://labs.aweber.com/apps):


### PR DESCRIPTION
There must be quotes around the keys in the credentials.ini file, the readme did not reflect this. If you add your keys without the quotes the examples fail with a "no oauth token in request" sort of error.