### PR TITLE
Update opens clicks examples

### DIFF
--- a/csharp/AWeber.Examples/BaseDemo.cs
+++ b/csharp/AWeber.Examples/BaseDemo.cs
@@ -92,7 +92,9 @@ namespace AWeber.Examples
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
                 var response = await Client.SendAsync(request);
-                var contentString = await response.Content.ReadAsStringAsync();
+                var byteArray = await response.Content.ReadAsByteArrayAsync();
+                var contentString = Encoding.UTF8.GetString(byteArray, 0, byteArray.Length);
+
                 if (!response.IsSuccessStatusCode)
                 {
                     ThrowError(response.StatusCode, contentString);
@@ -111,7 +113,9 @@ namespace AWeber.Examples
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
             var response = await Client.SendAsync(request);
-            var contentString = await response.Content.ReadAsStringAsync();
+            var byteArray = await response.Content.ReadAsByteArrayAsync();
+            var contentString = Encoding.UTF8.GetString(byteArray, 0, byteArray.Length);
+
             if (!response.IsSuccessStatusCode)
             {
                 ThrowError(response.StatusCode, contentString);
@@ -127,7 +131,9 @@ namespace AWeber.Examples
             request.Content = new StringContent(JsonConvert.SerializeObject(payload, _serializerSettings), Encoding.UTF8);
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
             var response = await Client.SendAsync(request);
-            var contentString = await response.Content.ReadAsStringAsync();
+            var byteArray = await response.Content.ReadAsByteArrayAsync();
+            var contentString = Encoding.UTF8.GetString(byteArray, 0, byteArray.Length);
+
             if (!response.IsSuccessStatusCode)
             {
                 ThrowError(response.StatusCode, contentString);
@@ -144,7 +150,8 @@ namespace AWeber.Examples
             var response = await Client.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
-                var contentString = await response.Content.ReadAsStringAsync();
+                var byteArray = await response.Content.ReadAsByteArrayAsync();
+                var contentString = Encoding.UTF8.GetString(byteArray, 0, byteArray.Length);
                 ThrowError(response.StatusCode, contentString);
             }
             return response.Headers.Location;
@@ -158,7 +165,8 @@ namespace AWeber.Examples
             var response = await Client.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
-                var contentString = await response.Content.ReadAsStringAsync();
+                var byteArray = await response.Content.ReadAsByteArrayAsync();
+                var contentString = Encoding.UTF8.GetString(byteArray, 0, byteArray.Length);
                 ThrowError(response.StatusCode, contentString);
             }
             return response.Headers.Location;
@@ -170,7 +178,9 @@ namespace AWeber.Examples
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
             request.Content = new FormUrlEncodedContent(payload);
             var response = await Client.SendAsync(request);
-            var contentString = await response.Content.ReadAsStringAsync();
+            var byteArray = await response.Content.ReadAsByteArrayAsync();
+            var contentString = Encoding.UTF8.GetString(byteArray, 0, byteArray.Length);
+
             if (!response.IsSuccessStatusCode)
             {
                 ThrowError(response.StatusCode, contentString);
@@ -185,7 +195,8 @@ namespace AWeber.Examples
             var response = await Client.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
-                var contentString = await response.Content.ReadAsStringAsync();
+                var byteArray = await response.Content.ReadAsByteArrayAsync();
+                var contentString = Encoding.UTF8.GetString(byteArray, 0, byteArray.Length);
                 ThrowError(response.StatusCode, contentString);
             }
         }

--- a/csharp/AWeber.Examples/Models/Broadcast.cs
+++ b/csharp/AWeber.Examples/Models/Broadcast.cs
@@ -11,6 +11,7 @@ namespace AWeber.Examples.Models
         [JsonProperty("body_amp")] public string BodyAmp { get; set; }
         [JsonProperty("broadcast_id")] public int BroadcastId { get; set; }
         [JsonProperty("click_tracking_enabled")] public bool ClickTrackingEnabled { get; set; }
+        [JsonProperty("clicks_collection_link")] public string ClicksCollectionLink { get; set; }
         [JsonProperty("created_at")] public string CreatedAt { get; set; }
         [JsonProperty("exclude_lists")] public IList<string> ExcludeLists { get; set; }
         [JsonProperty("facebook_integration")] public string FacebookIntegration { get; set; }
@@ -19,6 +20,7 @@ namespace AWeber.Examples.Models
         [JsonProperty("is_archived")] public bool IsArchived { get; set; }
         [JsonProperty("links")] public IList<HtmlLink> Links { get; set; }
         [JsonProperty("notify_on_send")] public bool NotifyOnSend { get; set; }
+        [JsonProperty("opens_collection_link")] public string OpensCollectionLink { get; set; }
         [JsonProperty("scheduled_for")] public string ScheduledFor { get; set; }
         [JsonProperty("segment_link")] public string SegmentLink { get; set; }
         [JsonProperty("segment_name")] public string SegmentName { get; set; }

--- a/csharp/AWeber.Examples/Models/BroadcastClick.cs
+++ b/csharp/AWeber.Examples/Models/BroadcastClick.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace AWeber.Examples.Models
+{
+    public class BroadcastClick
+    {
+        [JsonProperty("subscriber_link")] public string SubscriberLink { get; set; }
+        [JsonProperty("resource_type_link")] public string ResourceTypeLink { get; set; }
+        [JsonProperty("email")] public string Email { get; set; }
+        [JsonProperty("event_time")] public DateTime EventTime { get; set; }
+        [JsonProperty("type")] public string Type { get; set; }
+    }
+}

--- a/csharp/AWeber.Examples/Models/BroadcastOpen.cs
+++ b/csharp/AWeber.Examples/Models/BroadcastOpen.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace AWeber.Examples.Models
+{
+    public class BroadcastOpen
+    {
+        [JsonProperty("subscriber_link")] public string SubscriberLink { get; set; }
+        [JsonProperty("resource_type_link")] public string ResourceTypeLink { get; set; }
+        [JsonProperty("email")] public string Email { get; set; }
+        [JsonProperty("event_time")] public DateTime EventTime { get; set; }
+        [JsonProperty("type")] public string Type { get; set; }
+    }
+}

--- a/csharp/AWeber.Examples/Models/SplitTest.cs
+++ b/csharp/AWeber.Examples/Models/SplitTest.cs
@@ -6,7 +6,7 @@ namespace AWeber.Examples.Models
     {
         [JsonProperty("components_collection_link")] public string ComponentsCollectionLink { get; set; }
         [JsonProperty("http_etag")] public string HttpEtag { get; set; }
-        [JsonProperty("id")] public int Id { get; set; }
+        [JsonProperty("id")] public string Id { get; set; }
         [JsonProperty("is_active")] public bool IsActive { get; set; }
         [JsonProperty("javascript_source_link")] public string JavascriptSourceLink { get; set; }
         [JsonProperty("name")] public string Name { get; set; }

--- a/csharp/AWeber.Examples/Models/Webform.cs
+++ b/csharp/AWeber.Examples/Models/Webform.cs
@@ -7,7 +7,7 @@ namespace AWeber.Examples.Models
         [JsonProperty("conversion_percentage")] public double ConversionPercentage { get; set; }
         [JsonProperty("html_source_link")] public string HtmlSourceLink { get; set; }
         [JsonProperty("http_etag")] public string HttpEtag { get; set; }
-        [JsonProperty("id")] public int Id { get; set; }
+        [JsonProperty("id")] public string Id { get; set; }
         [JsonProperty("is_active")] public bool IsActive { get; set; }
         [JsonProperty("javascript_source_link")] public string JavascriptSourceLink { get; set; }
         [JsonProperty("name")] public string Name { get; set; }

--- a/node/get-broadcast-opens-clicks.js
+++ b/node/get-broadcast-opens-clicks.js
@@ -18,7 +18,7 @@ const qs = require("querystring");
 async function getCollection(accessToken,url) {
     let res;
     const collection = [];
-    console.log({accessToken})
+    console.log({accessToken});
     while(url) {
         res = await fetch(url,{
             headers:{
@@ -26,7 +26,7 @@ async function getCollection(accessToken,url) {
             }
         });
         let page = await res.json();
-        console.log("got page",{page})
+        console.log("got page",{page});
         collection.push(...page.entries);
         url = page.next_collection_link;
     }
@@ -94,12 +94,12 @@ async function getWithRetry(accessToken, url) {
 
     // get all the accounts entries
     const accounts = await getCollection(accessToken, BASE_URL + 'accounts');
-    console.log({accounts})
+    console.log({accounts});
     const accountUrl = accounts[0]['self_link'];
 
     // get all the list entries for the first account
     const listsUrl = accounts[0]['lists_collection_link'];
-    const lists = await getCollection( accessToken, listsUrl);
+    const lists = await getCollection(accessToken, listsUrl);
 
     const broadcastsUrl = lists[0]['sent_broadcasts_link'];
     console.log(broadcastsUrl);

--- a/php/get-broadcast-opens-clicks
+++ b/php/get-broadcast-opens-clicks
@@ -80,39 +80,22 @@ $listsUrl = $accounts[0]['lists_collection_link'];
 $lists = getCollection($client, $accessToken, $listsUrl);
 
 // get a sent broadcast
-$params = array(
-    'ws.op' => 'find',
-    'campaign_type' => 'b'
-);
-$campaignsUrl = $lists[0]['campaigns_collection_link'];
-$broadcastsUrl = $campaignsUrl . '?' . http_build_query($params);
-$sentBroadcasts = getCollection($client, $accessToken, $broadcastsUrl);
-$broadcast = $sentBroadcasts[0];
+$sentBroadcasts = getCollection($client, $accessToken, $lists[0]['sent_broadcasts_link']);
+$broadcast_response = getWithRetry($client, $accessToken, $sentBroadcasts[0]['self_link']);
+$broadcast = json_decode($broadcast_response->getBody(), true);
 echo 'Broadcast: ';
 print_r($broadcast);
 
-// A broadcast is the receipt of sending email messages to a list.
-
-// mapping of subscriber url to email address
-$subscriberCache = array();
-
-$links = getCollection($client, $accessToken, $broadcast['links_collection_link']);
+echo "\nOpens for broadcast:\n";
+$opensUrl = $broadcast['opens_collection_link'];
+$opens = getCollection($client, $accessToken, $opensUrl);
+foreach ($opens as $open) {
+    echo "    [{$open['event_time']}]: {$open['email']}\n";
+}
 
 echo "\nClicks for broadcast:\n";
-foreach ($links as $link) {
-    echo "{$link['url']}\n";
-    $clicksUrl = $link['clicks_collection_link'];
-    $clicks = getCollection($client, $accessToken, $clicksUrl);
-    foreach ($clicks as $click) {
-        $clickSubLink = $click['subscriber_link'];
-        $cachedSubscriber = $subscriberCache[$clickSubLink];
-        if (isset($cachedSubscriber)) {
-            $email = $cachedSubscriber['email'];
-        } else {
-            $clickSub = getWithRetry($client, $accessToken, $clickSubLink)->getBody();
-            $clickSubBody = json_decode($clickSub, true);
-            $email = $clickSubBody['email'];
-        }
-        echo "    {$click['event_time']}: {$email}\n";
-    }
+$clicksUrl = $broadcast['clicks_collection_link'];
+$clicks = getCollection($client, $accessToken, $clicksUrl);
+foreach ($clicks as $click) {
+    echo "    [{$click['event_time']}]: {$open['email']}\n";
 }

--- a/postman/Get Broadcast Opens Clicks.postman_collection.json
+++ b/postman/Get Broadcast Opens Clicks.postman_collection.json
@@ -1,0 +1,242 @@
+{
+	"info": {
+		"_postman_id": "e04472af-b419-42e7-8e48-0b018ba4a9b8",
+		"name": "Get Broadcast Opens Clicks",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get Account",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "ef9624e0-b01e-4135-a82d-56faf1bda107",
+						"exec": [
+							"",
+							"pm.test(\"Check access_token is defined and not empty\", function(){",
+							"   pm.expect(pm.environment.has(\"access_token\")).to.eql(true) && pm.expect(pm.environment.get(\"access_token\")).not.eql('');",
+							"});",
+							"",
+							"pm.test(\"Successfully get an account Id\", function(){",
+							"    pm.response.to.have.status(200);",
+							"    var jsonData = pm.response.json();",
+							"    pm.expect(jsonData.entries.length).to.be.above(0);",
+							"    pm.globals.set(\"accountId\",jsonData.entries[0].id ) ;   ",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/accounts",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"accounts"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Lists on Account",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "587bd57c-b791-4cc3-9517-5070b0b07c5a",
+						"exec": [
+							"var jsonData = pm.response.json();",
+							"",
+							"pm.test(\"Successfully selected a random listId\", function() {",
+							"        var list_entry = Math.floor((Math.random() * jsonData.entries.length ));",
+							"        pm.globals.set(\"listId\",jsonData.entries[list_entry].id );",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/accounts/{{accountId}}/lists",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"accounts",
+						"{{accountId}}",
+						"lists"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Sent Broadcasts",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "01923a96-03d9-44ad-983a-f93a81b8844d",
+						"exec": [
+							"var jsonData = pm.response.json();",
+							"pm.globals.set(\"sent_broadcast_link\", '');",
+							"",
+							"pm.test(\"Found sent broadcasts on the selected list\", function() {",
+							"    pm.expect(jsonData.entries.length).to.be.above(0);",
+							"    pm.globals.set(\"sent_broadcast_link\", jsonData.entries[0].self_link);",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/accounts/{{accountId}}/lists/{{listId}}/broadcasts?status=sent",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"accounts",
+						"{{accountId}}",
+						"lists",
+						"{{listId}}",
+						"broadcasts"
+					],
+					"query": [
+						{
+							"key": "status",
+							"value": "sent"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get First Sent Broadcast",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "1961b85a-e914-4b57-80c4-ee5c289959ff",
+						"exec": [
+							"var jsonData = pm.response.json();",
+							"pm.globals.set(\"opens_collection_link\", '');",
+							"pm.globals.set(\"clicks_collection_link\", '');",
+							"",
+							"pm.test(\"Found first sent broadcast on the selected list\", function() {  ",
+							"    pm.globals.set(\"opens_collection_link\", jsonData.opens_collection_link);",
+							"    pm.globals.set(\"clicks_collection_link\", jsonData.clicks_collection_link);",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{sent_broadcast_link}}",
+					"host": [
+						"{{sent_broadcast_link}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Opens",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{opens_collection_link}}",
+					"host": [
+						"{{opens_collection_link}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Clicks",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{clicks_collection_link}}",
+					"host": [
+						"{{clicks_collection_link}}"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"auth": {
+		"type": "oauth2",
+		"oauth2": [
+			{
+				"key": "accessToken",
+				"value": "{{access_token}}",
+				"type": "string"
+			},
+			{
+				"key": "addTokenTo",
+				"value": "header",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "56fa0b48-934f-485d-b6b8-b4f3ade79807",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "282e0d93-2bb3-4ab8-94c0-b6dc32001bf4",
+				"type": "text/javascript",
+				"exec": [
+					"pm.test(\"Successfully submitted request\", function(){",
+					"    pm.response.to.have.status(200);",
+					"});",
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"id": "d843daab-31cf-4a98-8441-8f9d1b77d1e5",
+			"key": "base_url",
+			"value": "https://api.aweber.com/1.0",
+			"type": "string"
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/python/get-broadcast-opens-clicks
+++ b/python/get-broadcast-opens-clicks
@@ -94,32 +94,15 @@ lists_url = accounts[0]['lists_collection_link']
 lists = get_collection(lists_url)
 
 # get a sent broadcast
-params = urlencode({'ws.op': 'find', 'campaign_type': 'b'})
-broadcasts_url = '{}?{}'.format(lists[0]['campaigns_collection_link'], params)
-sent_broadcasts = get_collection(broadcasts_url)
-broadcast = sent_broadcasts[0]
+sent_broadcasts = get_collection(lists[0]['sent_broadcasts_link'])
+broadcast_response = get_with_retry(sent_broadcasts[0]['self_link'])
+broadcast = broadcast_response.json()
 print('Broadcast: {}'.format(json.dumps(broadcast, indent=4)))
 
-# A broadcast is the receipt of sending email messages to a list.
-
-# mapping of subscriber url to email address
-subscriber_cache = {}
-
-links_url = broadcast['links_collection_link']
-links = get_collection(links_url)
+print('Opens for broadcast:')
+for bc_open in get_collection(broadcast['opens_collection_link']):
+    print(f"    [{bc_open['event_time']}]: {bc_open['email']}")
 
 print('Clicks for broadcast:')
-for link in links:
-    print(link['url'])
-    clicks_url = link['clicks_collection_link']
-    for click in get_collection(clicks_url):
-        click_sub_link = click['subscriber_link']
-        email = subscriber_cache.get(click_sub_link)
-        if not email:
-            click_response = get_with_retry(click_sub_link)
-            click_response.raise_for_status()
-            click_body = click_response.json()
-            subscriber_cache[link] = click_body
-        print('    {}: {}'.format(click['event_time'],
-                                  subscriber_cache[click_sub_link]))
-
+for bc_open in get_collection(broadcast['clicks_collection_link']):
+    print(f"    [{bc_open['event_time']}]: {bc_open['email']}")

--- a/ruby/get_broadcast_opens_clicks.rb
+++ b/ruby/get_broadcast_opens_clicks.rb
@@ -43,47 +43,27 @@ accounts = get_collection(conn, "#{BASE_URL}accounts")
 lists_url = accounts[0]['lists_collection_link']
 lists = get_collection(conn, lists_url)
 
-params = {
-  'ws.op' => 'find',
-  'campaign_type' => 'b'
-}
-campaigns_url = lists[0]['campaigns_collection_link']
-broadcasts_url = "#{campaigns_url}?#{URI.encode_www_form(params)}"
+broadcasts_url = lists[0]['sent_broadcasts_link']
 puts broadcasts_url
 
 sent_broadcasts = get_collection(conn, broadcasts_url)
-broadcast = sent_broadcasts[0]
+broadcast_response = get_with_retry(sent_broadcasts[0]['self_link'], credentials)
+broadcast = JSON.parse(broadcast_response.body)
 puts "Broadcast:"
 puts broadcast
 
-messages_url = broadcast['message_collection_link']
-messages = get_collection(conn, messages_url)
-subscriber_cache = {}
+puts "Opens for broadcast:"
+opens_url = broadcast['opens_collection_link']
+opens = get_collection(conn, opens_url)
 
-messages.each do |message|
-  if message['total_opens'] > 0
-    open_sub_link = message['subscriber_link']
-    open_sub = get_with_retry(open_sub_link,credentials)
-    open_sub_body = JSON.parse(open_sub.body)
-    subscriber_cache[open_sub_link] = open_sub_body['email']
-  end
+opens.each do |open|
+  puts "    [#{open['event_time']}]: #{open['email']}"
 end
 
-links = get_collection(conn, broadcast['links_collection_link'])
 puts "Clicks for broadcast:"
-links.each do |link|
-  clicks_url = link['clicks_collection_link']
-  clicks = get_collection(conn, clicks_url)
-  clicks.each do |click|
-    click_sub_link = click['subscriber_link']
-    cached_subscriber = subscriber_cache[click_sub_link]
-    if(cached_subscriber)
-      email = cached_subscriber['email']
-    else
-      click_sub = get_with_retry(click_sub_link,credentials)
-      click_sub_body = JSON.parse(click_sub.body)
-      email = click_sub_body['email']
-    end
-    puts "    #{click['event_time']}: #{email}"
-  end
+clicks_url = broadcast['clicks_collection_link']
+clicks = get_collection(conn, clicks_url)
+
+clicks.each do |open|
+  puts "    [#{open['event_time']}]: #{open['email']}"
 end


### PR DESCRIPTION
Main edit:
Update the broadcast opens and clicks examples to use our latest [opens](https://api.aweber.com/#tag/Broadcasts%2Fpaths%2F~1accounts~1%7BaccountId%7D~1lists~1%7BlistId%7D~1broadcasts~1%7BbroadcastId%7D~1opens%2Fget) and [clicks](https://api.aweber.com/#tag/Broadcasts/paths/~1accounts~1{accountId}~1lists~1{listId}~1broadcasts~1{broadcastId}~1clicks/get) collection endpoints. This will simplify the examples greatly.

Other fixes:
- Using utf-8 encoding on response for csharp examples
- Add semicolons to node examples when missing
- Update webforms to a string id to accomodate webformsplittest overloading of the model (webformsplittests have string ids whereas webforms are able to be cast as integers, because we use the same model for both, strings need to be the type here)